### PR TITLE
Implement backoff retry mechanism

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 bs4
 Faker
-httpx
 lxml
 pre-commit
 pytest
 pytest-cov
+requests
 sphinx-autodoc-typehints

--- a/sec_edgar_downloader/_constants.py
+++ b/sec_edgar_downloader/_constants.py
@@ -11,7 +11,7 @@ SEC_EDGAR_ARCHIVES_BASE_URL = "https://www.sec.gov/Archives/edgar/data"
 SEC_EDGAR_RATE_LIMIT_SLEEP_INTERVAL = 0.1
 
 # Number of times to retry a request to sec.gov
-MAX_RETRIES = 5
+MAX_RETRIES = 10
 
 DATE_FORMAT_TOKENS = "%Y-%m-%d"
 DEFAULT_BEFORE_DATE = date.today()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url="https://github.com/jadchaar/sec-edgar-downloader",
     packages=["sec_edgar_downloader"],
     zip_safe=False,
-    install_requires=["httpx", "bs4", "lxml", "Faker"],
+    install_requires=["requests", "bs4", "lxml", "Faker"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     doc8
     sphinx
     sphinx_autodoc_typehints
-    httpx
+    requests
     bs4
     Faker
 allowlist_externals = make


### PR DESCRIPTION
Fixes: https://github.com/jadchaar/sec-edgar-downloader/issues/77

The httpx package does not support backoff retry mechanisms, so I have reverted back to using requests.