### PR TITLE
Update _utils.py

### DIFF
--- a/sec_edgar_downloader/_utils.py
+++ b/sec_edgar_downloader/_utils.py
@@ -192,7 +192,8 @@ def get_filing_urls_to_download(
                 is_amend = hit_filing_type[-2:] == "/A"
                 if not include_amends and is_amend:
                     continue
-
+                if is_amend:
+                    num_filings_to_download+=1
                 # Work around bug where incorrect filings are sometimes included.
                 # For example, AAPL 8-K searches include N-Q entries.
                 if not is_amend and hit_filing_type != filing_type:


### PR DESCRIPTION
If we are including amends, then we should more files. Else, currently last 5 years include the amends too. We don't know how many amendments there are, hence increasing the number of files to download each time we find an amendment will download the accurate number of files