### PR TITLE
Update _orchestrator.py - lstrip('0')

### DIFF
--- a/sec_edgar_downloader/_orchestrator.py
+++ b/sec_edgar_downloader/_orchestrator.py
@@ -107,7 +107,7 @@ def aggregate_filings_to_download(
 
 
 def get_to_download(cik: str, acc_num: str, doc: str) -> ToDownload:
-    cik = cik.strip("0")
+    cik = cik.lstrip("0")
     acc_num_no_dash = acc_num.replace("-", "")
     raw_filing_uri = URL_FILING.format(
         cik=cik, acc_num_no_dash=acc_num_no_dash, document=f"{acc_num}.txt"


### PR DESCRIPTION
the CIK can have trailing 0's, so it is better to use .lstrip('0')