### PR TITLE
Fix issue preventing DEF 14A filings from downloading

### DIFF
--- a/sec_edgar_downloader/_orchestrator.py
+++ b/sec_edgar_downloader/_orchestrator.py
@@ -76,12 +76,11 @@ def aggregate_filings_to_download(
         for acc_num, form, doc, f_date in zip(  # noqa: B905
             accession_numbers, forms, documents, filing_dates
         ):
+            is_amend = form.endswith(AMENDS_SUFFIX)
+            form = form[:-2] if is_amend else form
             if (
-                form.rstrip(AMENDS_SUFFIX) != download_metadata.form
-                or (
-                    not download_metadata.include_amends
-                    and form.endswith(AMENDS_SUFFIX)
-                )
+                form != download_metadata.form
+                or (not download_metadata.include_amends and is_amend)
                 or not within_requested_date_range(download_metadata, f_date)
             ):
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,11 @@ def form_10k() -> str:
 
 
 @pytest.fixture(scope="session")
+def form_def_14a() -> str:
+    return "DEF 14A"
+
+
+@pytest.fixture(scope="session")
 def apple_cik() -> str:
     return "0000320193"
 

--- a/tests/test_end_to_end_integration.py
+++ b/tests/test_end_to_end_integration.py
@@ -69,12 +69,26 @@ def test_integration_apple_10_k_given_include_amends(
     dl, dl_path = network_downloader
     assert directory_is_empty(dl_path)
 
-    dl, dl_path = network_downloader
-    assert directory_is_empty(dl_path)
-
     dl.get(form_10k, apple_cik, before=date(2023, 9, 1), include_amends=True)
 
     downloaded_file_path = dl_path / ROOT_SAVE_FOLDER_NAME / apple_cik / form_10k
+    downloaded_acc_nums = downloaded_file_path.glob("*")
+    forms = downloaded_file_path.glob("*/*.txt")
+
+    assert len(list(downloaded_acc_nums)) == len(list(forms)) == 29
+    assert all(form.stat() > 0 for form in forms)
+
+
+# Integration test for issue #129
+def test_integration_apple_def_14a_given_include_amends(
+    network_downloader, form_def_14a, apple_cik
+):
+    dl, dl_path = network_downloader
+    assert directory_is_empty(dl_path)
+
+    dl.get(form_def_14a, apple_cik, before=date(2023, 10, 7), include_amends=True)
+
+    downloaded_file_path = dl_path / ROOT_SAVE_FOLDER_NAME / apple_cik / form_def_14a
     downloaded_acc_nums = downloaded_file_path.glob("*")
     forms = downloaded_file_path.glob("*/*.txt")
 


### PR DESCRIPTION
 It seems to be an issue with the use of `rstrip` when cleaning up the amends suffix here: https://github.com/jadchaar/sec-edgar-downloader/blob/b919ddd70e8f08ed00731cb52dfde9ff5e7cab7d/sec_edgar_downloader/_orchestrator.py#L80

Upon testing, it appears that the use of `rstrip` is leading to some unintended issues when a filing type ends with any type of `A`:
```
>>> test_no_amend = "DEF 14A"
>>> test_no_amend.rstrip("/A")
DEF 14
>>> test_amend = "DEF 14A/A"
>>> test_amend.rstrip("/A")
DEF 14
```

Solution is to switch from `rstrip` to `[:-2]` if an amend is detected. When an amend is not detected, the form will be used as-is and not manipulated.

Closes: https://github.com/jadchaar/sec-edgar-downloader/issues/129